### PR TITLE
feat: add file attachment support for widget and agent dashboard

### DIFF
--- a/custom-widget/agent-dashboard.html
+++ b/custom-widget/agent-dashboard.html
@@ -492,12 +492,24 @@
             <div id="message-input-area" class="hidden bg-white border-t border-gray-200 p-4">
                 <form id="message-form" class="flex gap-3 items-end">
                     <div class="flex-1 relative">
-                        <textarea 
-                            id="message-input" 
-                            placeholder="Rašykite savo pranešimą..."
-                            class="w-full border border-gray-300 rounded-lg px-4 py-2 resize-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-                            style="resize: none; overflow-y: auto; height: 80px; min-height: 80px; max-height: 300px; transition: height 0.2s ease;"
-                        ></textarea>
+                        <input
+                            type="file"
+                            id="agent-file-input"
+                            style="display: none;"
+                            accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.txt"
+                        />
+                        <div class="flex items-start gap-2">
+                            <button type="button" id="agent-attach-button" class="text-gray-500 hover:text-gray-700 p-2 transition-colors" title="Prisegti failą">
+                                <i class="fas fa-paperclip text-xl"></i>
+                            </button>
+                            <textarea
+                                id="message-input"
+                                placeholder="Rašykite savo pranešimą..."
+                                class="flex-1 border border-gray-300 rounded-lg px-4 py-2 resize-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                                style="resize: none; overflow-y: auto; height: 80px; min-height: 80px; max-height: 300px; transition: height 0.2s ease;"
+                            ></textarea>
+                        </div>
+                        <div id="agent-file-preview" class="hidden mt-2 p-2 bg-gray-100 rounded-lg text-sm"></div>
                     </div>
                     <div class="flex flex-col items-end gap-2">
                         <button type="button" onclick="dashboard.getAIAssistance()" class="bg-gray-100 hover:bg-gray-200 text-gray-700 px-3 py-1.5 rounded text-sm flex items-center transition-colors">

--- a/custom-widget/backend/prisma/schema.prisma
+++ b/custom-widget/backend/prisma/schema.prisma
@@ -22,7 +22,7 @@ model messages {
   senderType   SenderType
   content      String
   message_type MessageType @default(text)
-  metadata     Json?
+  metadata     Json?       // For file attachments: {filename, path, mimetype, size, url}
   created_at   DateTime    @default(now())
   users        users?      @relation(fields: [sender_id], references: [id])
   tickets      tickets     @relation(fields: [ticket_id], references: [id], onDelete: Cascade)

--- a/custom-widget/backend/src/app.js
+++ b/custom-widget/backend/src/app.js
@@ -58,6 +58,7 @@ const userRoutes = require('./routes/userRoutes');
 const activityRoutes = require('./routes/activityRoutes');
 const logsRoutes = require('./routes/logsRoutes');
 const createDocsRoutes = require('./routes/docsRoutes');
+const uploadRoutes = require('./routes/uploadRoutes');
 
 // Import services
 const WebSocketService = require('./services/websocketService');
@@ -128,6 +129,7 @@ function createApp() {
     app.use('/api/users', userRoutes); // User management routes (admin only)
     app.use('/api/activities', activityRoutes); // Activity logging routes
     app.use('/api/logs', logsRoutes); // Centralized logging routes (admin only)
+    app.use('/api', uploadRoutes); // File upload routes
     app.use('/api', createConversationRoutes(io));
     app.use('/api', createAgentRoutes(io));
     app.use('/api/knowledge', createKnowledgeRoutes()); // Knowledge management routes

--- a/custom-widget/backend/src/routes/uploadRoutes.js
+++ b/custom-widget/backend/src/routes/uploadRoutes.js
@@ -1,0 +1,135 @@
+/**
+ * FILE UPLOAD ROUTES
+ *
+ * Main Purpose: Handle file attachment uploads for messages
+ *
+ * Key Responsibilities:
+ * - File Upload: Accept and validate file uploads
+ * - Storage Management: Store files securely on filesystem
+ * - Metadata Generation: Create file metadata for database storage
+ *
+ * Endpoints:
+ * - POST /upload - Upload file attachment
+ *
+ * Security:
+ * - File type validation (images, PDFs, documents)
+ * - Size limit: 10MB
+ * - Filename sanitization
+ */
+const express = require('express');
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+const { v4: uuidv4 } = require('uuid');
+
+const router = express.Router();
+
+// Ensure uploads directory exists
+const uploadsDir = path.join(__dirname, '../../uploads');
+if (!fs.existsSync(uploadsDir)) {
+    fs.mkdirSync(uploadsDir, { recursive: true });
+}
+
+// Configure multer storage
+const storage = multer.diskStorage({
+    destination: function (req, file, cb) {
+        cb(null, uploadsDir);
+    },
+    filename: function (req, file, cb) {
+        // Generate unique filename: uuid-originalname
+        const uniqueId = uuidv4();
+        const sanitizedName = file.originalname.replace(/[^a-zA-Z0-9.-]/g, '_');
+        cb(null, `${uniqueId}-${sanitizedName}`);
+    }
+});
+
+// File filter for allowed types
+const fileFilter = (req, file, cb) => {
+    const allowedTypes = [
+        'image/jpeg',
+        'image/jpg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+        'application/pdf',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'text/plain'
+    ];
+
+    if (allowedTypes.includes(file.mimetype)) {
+        cb(null, true);
+    } else {
+        cb(new Error('Invalid file type. Allowed: images, PDF, DOC, DOCX, XLS, XLSX, TXT'), false);
+    }
+};
+
+// Configure multer upload
+const upload = multer({
+    storage: storage,
+    limits: {
+        fileSize: 10 * 1024 * 1024 // 10MB
+    },
+    fileFilter: fileFilter
+});
+
+// Upload endpoint
+router.post('/upload', upload.single('file'), (req, res) => {
+    try {
+        if (!req.file) {
+            return res.status(400).json({
+                success: false,
+                error: 'No file uploaded'
+            });
+        }
+
+        // Generate file metadata
+        const fileMetadata = {
+            filename: req.file.originalname,
+            storedFilename: req.file.filename,
+            path: req.file.path,
+            mimetype: req.file.mimetype,
+            size: req.file.size,
+            url: `/api/uploads/${req.file.filename}`
+        };
+
+        res.json({
+            success: true,
+            file: fileMetadata
+        });
+    } catch (error) {
+        console.error('Upload error:', error);
+        res.status(500).json({
+            success: false,
+            error: 'File upload failed'
+        });
+    }
+});
+
+// Serve uploaded files
+router.get('/uploads/:filename', (req, res) => {
+    const filename = req.params.filename;
+    const filePath = path.join(uploadsDir, filename);
+
+    // Security check: prevent directory traversal
+    if (!filePath.startsWith(uploadsDir)) {
+        return res.status(403).json({
+            success: false,
+            error: 'Access denied'
+        });
+    }
+
+    // Check if file exists
+    if (!fs.existsSync(filePath)) {
+        return res.status(404).json({
+            success: false,
+            error: 'File not found'
+        });
+    }
+
+    res.sendFile(filePath);
+});
+
+module.exports = router;

--- a/custom-widget/js/agent-dashboard/EventManager.js
+++ b/custom-widget/js/agent-dashboard/EventManager.js
@@ -24,6 +24,7 @@ export class EventManager {
         this.setupGlobalClickListener();
         this.setupArchiveToggleListener();
         this.setupBulkActionListeners();
+        this.setupFileAttachmentListeners();
     }
 
     /**
@@ -243,5 +244,51 @@ export class EventManager {
                 }
             });
         }
+    }
+
+    /**
+     * Setup file attachment listeners
+     */
+    setupFileAttachmentListeners() {
+        const attachButton = document.getElementById('agent-attach-button');
+        const fileInput = document.getElementById('agent-file-input');
+        const filePreview = document.getElementById('agent-file-preview');
+
+        if (!attachButton || !fileInput || !filePreview) {
+            console.warn('File attachment elements not found');
+            return;
+        }
+
+        // Attach button click - open file picker
+        attachButton.addEventListener('click', () => {
+            fileInput.click();
+        });
+
+        // File selection handler
+        fileInput.addEventListener('change', (e) => {
+            const file = e.target.files[0];
+            if (file) {
+                this.dashboard.selectedFile = file;
+                filePreview.classList.remove('hidden');
+                filePreview.innerHTML = `
+                    <div class="flex justify-between items-center">
+                        <span><i class="fas fa-paperclip mr-2"></i>${file.name}</span>
+                        <button type="button" id="agent-remove-file" class="text-red-600 hover:text-red-800">
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </div>
+                `;
+
+                // Remove file handler
+                const removeBtn = document.getElementById('agent-remove-file');
+                if (removeBtn) {
+                    removeBtn.addEventListener('click', () => {
+                        this.dashboard.selectedFile = null;
+                        fileInput.value = '';
+                        filePreview.classList.add('hidden');
+                    });
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
Implement file upload functionality allowing users and agents to send attachments (images, PDFs, documents) in chat conversations.

## Backend changes:
- Add multer-based upload endpoint at `/api/upload`
- Store files in `custom-widget/backend/uploads/` directory
- Implement file type validation and 10MB size limit
- Add file serving endpoint at `/api/uploads/:filename`
- Update conversation controller to handle file metadata

## Frontend changes:
- Add paperclip attach button to widget message input
- Add paperclip attach button to agent dashboard input
- Implement file preview with remove functionality
- Display images inline and documents as clickable links
- Store file metadata in message metadata field

## Security measures:
- File type validation (images, PDFs, docs, text)
- Filename sanitization to prevent directory traversal
- Size limit enforcement (10MB)

Closes #25

