### PR TITLE
feat: add privacy policy checkbox with full-screen overlay gate

### DIFF
--- a/custom-widget/backend/.env.example
+++ b/custom-widget/backend/.env.example
@@ -47,8 +47,8 @@ CHROMA_AUTH_TOKEN=your-chroma-auth-token
 # These are only used as fallbacks if database settings are not available
 WIDGET_NAME=Vilnius Assistant
 WIDGET_PRIMARY_COLOR=#2c5530
+PRIVACY_CHECKBOX_TEXT="I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms)."
 WIDGET_ALLOWED_DOMAINS=*
-PRIVACY_CHECKBOX_TEXT=I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms).
 
 # Database Configuration
 DATABASE_URL="postgresql://vilnius_user:secure_password@localhost:5432/vilnius_support"

--- a/custom-widget/backend/.env.example
+++ b/custom-widget/backend/.env.example
@@ -48,6 +48,7 @@ CHROMA_AUTH_TOKEN=your-chroma-auth-token
 WIDGET_NAME=Vilnius Assistant
 WIDGET_PRIMARY_COLOR=#2c5530
 WIDGET_ALLOWED_DOMAINS=*
+PRIVACY_CHECKBOX_TEXT=I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms).
 
 # Database Configuration
 DATABASE_URL="postgresql://vilnius_user:secure_password@localhost:5432/vilnius_support"

--- a/custom-widget/backend/prisma/seed.js
+++ b/custom-widget/backend/prisma/seed.js
@@ -119,6 +119,30 @@ async function main() {
     });
     console.log('✅ Created sample message');
 
+    // Create default branding settings including privacy checkbox text
+    const defaultBrandingSettings = [
+      {
+        setting_key: 'privacy_checkbox_text',
+        setting_value: 'I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms).',
+        setting_type: 'string',
+        description: 'Text shown in the privacy policy checkbox (supports Markdown)',
+        category: 'branding',
+        is_public: true,
+      },
+    ];
+
+    for (const setting of defaultBrandingSettings) {
+      await prisma.system_settings.upsert({
+        where: { setting_key: setting.setting_key },
+        update: {},
+        create: {
+          id: `setting_${setting.setting_key}`,
+          ...setting,
+        },
+      });
+    }
+    console.log('✅ Created default branding settings');
+
     console.log('\n🎉 Minimal database seeding completed successfully!');
     console.log('\nDefault credentials:');
     console.log('Admin: admin@vilnius.lt / admin123');

--- a/custom-widget/backend/prisma/seed.js
+++ b/custom-widget/backend/prisma/seed.js
@@ -123,7 +123,7 @@ async function main() {
     const defaultBrandingSettings = [
       {
         setting_key: 'privacy_checkbox_text',
-        setting_value: 'I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms).',
+        setting_value: process.env.PRIVACY_CHECKBOX_TEXT || 'I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms).',
         setting_type: 'string',
         description: 'Text shown in the privacy policy checkbox (supports Markdown)',
         category: 'branding',

--- a/custom-widget/backend/src/services/settingsService.js
+++ b/custom-widget/backend/src/services/settingsService.js
@@ -32,7 +32,8 @@ const SETTING_SCHEMAS = {
         widget_primary_color: z.string().regex(/^#[0-9A-Fa-f]{6}$/, 'Must be a valid hex color'),
         widget_allowed_domains: z.string().min(1),
         welcome_message: z.string().max(500).optional(),
-        user_message_color: z.string().regex(/^#[0-9A-Fa-f]{6}$/, 'Must be a valid hex color').optional()
+        user_message_color: z.string().regex(/^#[0-9A-Fa-f]{6}$/, 'Must be a valid hex color').optional(),
+        privacy_checkbox_text: z.string().min(1).max(500)
     },
     ai: {
         system_prompt: z.string().min(10).optional().or(z.literal('')),
@@ -92,6 +93,7 @@ const ENV_FALLBACKS = {
     widget_allowed_domains: process.env.WIDGET_ALLOWED_DOMAINS || '*',
     welcome_message: process.env.WELCOME_MESSAGE || 'Hello! How can I help you today?',
     user_message_color: process.env.USER_MESSAGE_COLOR || '#3b82f6',
+    privacy_checkbox_text: process.env.PRIVACY_CHECKBOX_TEXT || 'I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms).',
     system_prompt: process.env.SYSTEM_PROMPT || '',
     rag_k: parseInt(process.env.RAG_K) || 100,
     rag_similarity_threshold: parseFloat(process.env.RAG_SIMILARITY_THRESHOLD) || 0.7,

--- a/custom-widget/backend/src/services/settingsService.js
+++ b/custom-widget/backend/src/services/settingsService.js
@@ -505,7 +505,7 @@ class SettingsService extends EventEmitter {
     isPublicSetting(key, category) {
         // Most branding settings should be public for frontend access
         if (category === 'branding') {
-            return ['widget_name', 'widget_primary_color', 'welcome_message', 'user_message_color'].includes(key);
+            return ['widget_name', 'widget_primary_color', 'welcome_message', 'user_message_color', 'privacy_checkbox_text'].includes(key);
         }
         
         // AI settings should be accessible to admins for context engineering

--- a/custom-widget/js/settings/modules/BrandingConfigModule.js
+++ b/custom-widget/js/settings/modules/BrandingConfigModule.js
@@ -92,7 +92,8 @@ export class BrandingConfigModule {
             userMessageColorHexInput: document.getElementById('user-message-color-text'),
             allowedDomainsTextarea: document.getElementById('widget-allowed-domains'),
             welcomeMessageInput: document.getElementById('welcome-message'),
-            
+            privacyCheckboxTextInput: document.getElementById('privacy-checkbox-text'),
+
             // Form and buttons
             form: document.getElementById('branding-form'),
             saveButton: document.getElementById('branding-save-btn'),
@@ -186,7 +187,8 @@ export class BrandingConfigModule {
             'widget-primary-color-text',
             'user-message-color',
             'user-message-color-text',
-            'welcome-message'
+            'welcome-message',
+            'privacy-checkbox-text'
         ];
 
         inputs.forEach(inputId => {
@@ -275,7 +277,8 @@ export class BrandingConfigModule {
             widget_primary_color: document.getElementById('widget-primary-color')?.value || '#2c5530',
             user_message_color: document.getElementById('user-message-color')?.value || '#3b82f6',
             widget_allowed_domains: document.getElementById('widget-allowed-domains')?.value || '*',
-            welcome_message: document.getElementById('welcome-message')?.value || ''
+            welcome_message: document.getElementById('welcome-message')?.value || '',
+            privacy_checkbox_text: document.getElementById('privacy-checkbox-text')?.value || ''
         };
     }
 
@@ -373,7 +376,8 @@ export class BrandingConfigModule {
             widget_primary_color: '#2c5530',
             user_message_color: '#3b82f6',
             widget_allowed_domains: '*',
-            welcome_message: 'Hello! How can I help you today?'
+            welcome_message: 'Hello! How can I help you today?',
+            privacy_checkbox_text: 'I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms).'
         };
         
         for (const [key, defaultValue] of Object.entries(defaults)) {
@@ -579,6 +583,10 @@ export class BrandingConfigModule {
 
         if (this.elements.welcomeMessageInput) {
             this.elements.welcomeMessageInput.value = settings.welcome_message || 'Hello! How can I help you today?';
+        }
+
+        if (this.elements.privacyCheckboxTextInput) {
+            this.elements.privacyCheckboxTextInput.value = settings.privacy_checkbox_text || 'I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms).';
         }
 
         console.log('📝 BrandingConfigModule: Form populated from settings', settings);
@@ -929,9 +937,13 @@ export class BrandingConfigModule {
         if (this.elements.welcomeMessageInput) {
             this.currentSettings.welcome_message = this.elements.welcomeMessageInput.value;
         }
-        
+
         if (this.elements.allowedDomainsTextarea) {
             this.currentSettings.widget_allowed_domains = this.elements.allowedDomainsTextarea.value;
+        }
+
+        if (this.elements.privacyCheckboxTextInput) {
+            this.currentSettings.privacy_checkbox_text = this.elements.privacyCheckboxTextInput.value;
         }
     }
 
@@ -983,27 +995,34 @@ export class BrandingConfigModule {
      * Validate current settings
      */
     validateSettings() {
-        const { widget_name, widget_primary_color, widget_allowed_domains, welcome_message } = this.currentSettings;
+        const { widget_name, widget_primary_color, widget_allowed_domains, welcome_message, privacy_checkbox_text } = this.currentSettings;
         const errors = [];
-        
+
         // Widget name validation
         if (!widget_name?.trim()) {
             errors.push({ field: 'widget_name', message: 'Widget name is required' });
         } else if (widget_name.length > 100) {
             errors.push({ field: 'widget_name', message: 'Widget name must be 100 characters or less' });
         }
-        
+
         // Primary color validation
         if (!widget_primary_color || !/^#[0-9A-Fa-f]{6}$/.test(widget_primary_color)) {
             errors.push({ field: 'widget_primary_color', message: 'Primary color must be a valid hex color (e.g., #2c5530)' });
         }
-        
-        
+
+
         // Welcome message validation
         if (welcome_message && welcome_message.length > 500) {
             errors.push({ field: 'welcome_message', message: 'Welcome message must be 500 characters or less' });
         }
-        
+
+        // Privacy checkbox text validation
+        if (!privacy_checkbox_text?.trim()) {
+            errors.push({ field: 'privacy_checkbox_text', message: 'Privacy checkbox text is required' });
+        } else if (privacy_checkbox_text.length > 500) {
+            errors.push({ field: 'privacy_checkbox_text', message: 'Privacy checkbox text must be 500 characters or less' });
+        }
+
         // Allowed domains validation
         if (!widget_allowed_domains?.trim()) {
             errors.push({ field: 'widget_allowed_domains', message: 'Allowed domains setting is required' });
@@ -1048,7 +1067,15 @@ export class BrandingConfigModule {
                     errors.push('Welcome message must be 500 characters or less');
                 }
                 break;
-                
+
+            case 'privacy_checkbox_text':
+                if (!value?.trim()) {
+                    errors.push('Privacy checkbox text is required');
+                } else if (value.length > 500) {
+                    errors.push('Privacy checkbox text must be 500 characters or less');
+                }
+                break;
+
             case 'widget_allowed_domains':
                 if (!value?.trim()) {
                     errors.push('Allowed domains setting is required');
@@ -1111,8 +1138,8 @@ export class BrandingConfigModule {
      * Clear all field validation errors
      */
     clearAllFieldErrors() {
-        const fields = ['widget-name', 'widget-primary-color', 'widget-primary-color-text', 'welcome-message', 'widget-allowed-domains'];
-        
+        const fields = ['widget-name', 'widget-primary-color', 'widget-primary-color-text', 'welcome-message', 'privacy-checkbox-text', 'widget-allowed-domains'];
+
         fields.forEach(fieldId => {
             const input = document.getElementById(fieldId);
             if (input) {
@@ -1220,6 +1247,7 @@ export class BrandingConfigModule {
             this.elements.userMessageColorInput,
             this.elements.userMessageColorHexInput,
             this.elements.welcomeMessageInput,
+            this.elements.privacyCheckboxTextInput,
             this.elements.allowedDomainsTextarea
         ];
 

--- a/custom-widget/settings.html
+++ b/custom-widget/settings.html
@@ -1290,9 +1290,15 @@ KLAUSIMAS: {question}"
                                 <textarea id="welcome-message" name="welcome_message" rows="3" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-indigo-500 focus:border-indigo-500" placeholder="Hello! How can I help you today?"></textarea>
                                 <p class="text-xs text-gray-500 mt-1">Initial message shown when users open the chat</p>
                             </div>
+
+                            <div>
+                                <label for="privacy-checkbox-text" class="block text-sm font-medium text-gray-700 mb-2">Privacy Policy Checkbox Text</label>
+                                <textarea id="privacy-checkbox-text" name="privacy_checkbox_text" rows="3" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-indigo-500 focus:border-indigo-500" placeholder="I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms)."></textarea>
+                                <p class="text-xs text-gray-500 mt-1">Text shown with privacy checkbox. Supports Markdown for links (e.g., [Privacy Policy](https://...)). Max 500 characters.</p>
+                            </div>
                         </div>
                     </div>
-                    
+
                     <!-- Live Preview -->
                     <div class="mt-8">
                         <h3 class="text-lg font-medium text-gray-900 mb-4 border-b border-gray-200 pb-2">Live Preview</h3>

--- a/custom-widget/settings.html
+++ b/custom-widget/settings.html
@@ -1293,7 +1293,7 @@ KLAUSIMAS: {question}"
 
                             <div>
                                 <label for="privacy-checkbox-text" class="block text-sm font-medium text-gray-700 mb-2">Privacy Policy Checkbox Text</label>
-                                <textarea id="privacy-checkbox-text" name="privacy_checkbox_text" rows="3" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-indigo-500 focus:border-indigo-500" placeholder="I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms)."></textarea>
+                                <textarea id="privacy-checkbox-text" name="privacy_checkbox_text" rows="3" maxlength="500" required class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-indigo-500 focus:border-indigo-500" placeholder="I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms)."></textarea>
                                 <p class="text-xs text-gray-500 mt-1">Text shown with privacy checkbox. Supports Markdown for links (e.g., [Privacy Policy](https://...)). Max 500 characters.</p>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
Implements [GitHub issue #26](https://github.com/simonaszilinskas/lizdeika/issues/26) - Privacy policy acceptance gate for the chat widget.

## What's New

### User Experience
- **Full-screen privacy gate overlay** appears when users open the widget
- Users must **check the privacy policy checkbox** before accessing chat
- **"Pradėti pokalbį" (Start Chat) button** becomes enabled after checkbox is checked
- Clicking the button reveals the **full chat interface** (header, messages, input)
- Privacy acceptance **does NOT persist** across sessions (resets on page reload)

### Admin Configuration
- New **"Privacy Policy Checkbox Text"** field in Settings → Branding Config
- Full **Markdown support** for creating clickable links
- Example: `I agree to the [Privacy Policy](https://example.com/privacy) and [Terms of Service](https://example.com/terms).`
- **500 character limit** with validation
- **Live preview** updates as you type

## Technical Implementation

### Backend Changes
**Files Modified:**
- `custom-widget/backend/src/services/settingsService.js` - Added validation schema & env fallback
- `custom-widget/backend/prisma/seed.js` - Auto-creates privacy_checkbox_text setting
- `custom-widget/backend/.env.example` - Documented new PRIVACY_CHECKBOX_TEXT variable

**Database:**
- New setting: `privacy_checkbox_text` (branding category, public, max 500 chars)
- Accessible via `/api/config/branding` endpoint

### Frontend Widget Changes
**File: `custom-widget/widget.js`**
- Complete redesign of initial widget state
- Privacy gate overlay with:
  - Gradient background design
  - Welcome icon and "Sveiki!" heading
  - Descriptive privacy notice text
  - White card containing checkbox with Markdown-rendered text
  - Full-width "Pradėti pokalbį" button
- Chat interface (header + messages + input) hidden until acceptance
- Smooth transitions and visual feedback (opacity, scale effects)
- Absolute positioning ensures proper full-screen coverage

### Settings Dashboard Changes
**Files Modified:**
- `custom-widget/settings.html` - Added textarea input for privacy checkbox text
- `custom-widget/js/settings/modules/BrandingConfigModule.js` - Full integration:
  - Form element management
  - Validation (required, max 500 chars)
  - Live preview updates
  - Save/reset functionality

## Visual Design

### Privacy Gate (Before Acceptance)
```
┌─────────────────────────────────┐
│                                 │
│         [Chat Icon 80px]        │
│            Sveiki!              │
│    Privacy notice description   │
│                                 │
│  ┌───────────────────────────┐ │
│  │ ☐ Privacy policy text...  │ │
│  │   (with clickable links)  │ │
│  └───────────────────────────┘ │
│                                 │
│    [ Pradėti pokalbį ]          │
│                                 │
└─────────────────────────────────┘
```

### Chat Interface (After Acceptance)
```
┌─────────────────────────────────┐
│ Pagalbos asistentas         [X] │ ← Header
├─────────────────────────────────┤
│                                 │
│  AI: Labas! Kuo galiu padėti?  │
│                                 │
│  User: Klausimas...         →  │
│                                 │ ← Scrollable Messages
├─────────────────────────────────┤
│ [📎] [Input field...] [Send]    │ ← Input Area
└─────────────────────────────────┘
```

## Testing Completed
- ✅ Server starts successfully with new settings
- ✅ No JavaScript syntax errors
- ✅ Privacy checkbox text loads from API correctly
- ✅ Markdown links render and are clickable
- ✅ Start Chat button disabled/enabled state works
- ✅ Visual feedback on checkbox/button interaction
- ✅ Chat interface properly hidden until acceptance
- ✅ Header, scrolling, and layout work correctly
- ✅ Privacy gate covers entire widget area
- ✅ State resets on page reload (no persistence)

## Migration Notes
For existing installations, the privacy checkbox setting will be automatically created on first run via the seed script. Alternatively, it can be manually added via the admin settings panel.

## Screenshots
Privacy gate overlay appears before any chat interaction, ensuring users must acknowledge privacy policy before proceeding.

## Closes
Closes #26

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a privacy consent gate: users must check a Privacy Policy/Terms box before starting chat.
  - Added configurable privacy checkbox text (up to 500 characters, Markdown links supported) in Branding/Site settings, with live preview.
  - Widget now auto-loads privacy text from settings with sensible defaults if unavailable.
- Refactor
  - Updated widget initialization to load privacy settings before displaying the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->